### PR TITLE
chore(ci): update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Spell Check Repo
       uses: crate-ci/typos@685eb3d55be2f85191e8c84acb9f44d7756f84ab #v1.29.4

--- a/.github/workflows/test-custom-config.yaml
+++ b/.github/workflows/test-custom-config.yaml
@@ -14,7 +14,7 @@ jobs:
       group: "test-custom-config-${{ github.head_ref || github.ref }}"
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./
         with:
           client: go-ethereum

--- a/.github/workflows/test-simple.yaml
+++ b/.github/workflows/test-simple.yaml
@@ -14,7 +14,7 @@ jobs:
       group: "test-simple-${{ github.head_ref || github.ref }}"
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./
         with:
           client: go-ethereum

--- a/.github/workflows/test-skip-tests.yaml
+++ b/.github/workflows/test-skip-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       group: "test-skip-tests-${{ github.head_ref || github.ref }}"
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./
         with:
           client: go-ethereum

--- a/action.yaml
+++ b/action.yaml
@@ -93,13 +93,13 @@ runs:
   using: 'composite'
   steps:
     - name: Install go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: ${{ inputs.go_version }}
         cache: false
 
     - name: Checkout hive
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         repository: ${{ inputs.hive_repository }}
         ref: ${{ inputs.hive_version }}
@@ -171,14 +171,14 @@ runs:
 
     - name: Upload test results as workflow artifact
       if: ${{ inputs.workflow_artifact_upload == 'true' && inputs.skip_tests != 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         name: ${{ env.WORKFLOW_ARTIFACT_PREFIX }}-results.zip
         path: src/results
 
     - name: Upload client config as workflow artifact
       if: ${{ inputs.workflow_artifact_upload == 'true' && inputs.client_config != '' && inputs.skip_tests != 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
       with:
         name: ${{ env.WORKFLOW_ARTIFACT_PREFIX }}-client-config.yaml
         path: src/client-config.yaml


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.